### PR TITLE
fix: buy/sell resolve after actual swap, not after approval

### DIFF
--- a/src/helpers/TokenHelper.ts
+++ b/src/helpers/TokenHelper.ts
@@ -911,7 +911,7 @@ export class Token<T extends TokenType> {
       });
 
       if (!bondApproved) {
-        return this.approveBond({
+        await this.approveBond({
           ...params,
           tradeType: 'buy',
           amountToSpend: maxReserveAmount,
@@ -947,7 +947,7 @@ export class Token<T extends TokenType> {
       } as BondApprovedParams<T>);
 
       if (!bondApproved) {
-        return this.approveBond({
+        await this.approveBond({
           ...params,
           tradeType: 'sell',
           amountToSpend: amount,
@@ -1001,7 +1001,7 @@ export class Token<T extends TokenType> {
       } as BondApprovedParams<T>);
 
       if (!bondApproved) {
-        return this.approveBond({
+        await this.approveBond({
           ...params,
           tradeType: 'sell',
           amountToSpend: amount,
@@ -1075,7 +1075,7 @@ export class Token<T extends TokenType> {
     );
 
     if (!approved) {
-      return this.approveContract(
+      await this.approveContract(
         {
           ...params,
           allowanceAmount: totalAmount,


### PR DESCRIPTION
## Problem

`buy()`, `sell()`, `sellWithZap()`, and `createAirdrop()` all returned early after the ERC-20 approval transaction, never executing the actual trade. Callers had to invoke the method twice: once for approval, once for the swap.

```typescript
// Before fix: first call resolves after approval only
await token.buy({ amount: 1000n, slippage: 500 }); // ← returns approval receipt
// No tokens received! Must call again:
await token.buy({ amount: 1000n, slippage: 500 }); // ← now actually buys
```

## Root Cause

`return this.approveBond(...)` exits the method after approval completes, skipping the subsequent `bondContract.write()` call.

## Fix

Changed `return this.approveBond(...)` → `await this.approveBond(...)` in all four methods so approval completes first, then execution falls through to the actual contract call (mint/burn/burnToEth/createAirdrop).

**Affected methods:**
- `buy()` — approval then `mint()`
- `sell()` — approval then `burn()`
- `sellWithZap()` — approval then `burnToEth()`
- `createAirdrop()` — approval then airdrop creation

Fixes #10